### PR TITLE
Add various helpers and predicates to mpl::Type and metapredicates.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(hyperion_mpl LANGUAGES CXX VERSION 0.11.0)
+project(hyperion_mpl LANGUAGES CXX VERSION 0.12.0)
 
 include(CTest)
 

--- a/include/hyperion/mpl/list.h
+++ b/include/hyperion/mpl/list.h
@@ -511,8 +511,8 @@ namespace hyperion::mpl {
             requires(std::invocable<TVisitor, as_meta<TTypes>> && ...)
                     && (std::same_as<std::invoke_result_t<TVisitor, as_meta<TTypes>>, void> && ...)
                     && (TCount::value <= sizeof...(TTypes))
-        constexpr auto for_each_n(TVisitor&& vis, [[maybe_unused]] TCount count) const noexcept
-            -> void {
+        constexpr auto
+        for_each_n(TVisitor&& vis, [[maybe_unused]] TCount count) const noexcept -> void {
             return typename detail::
                 pop_back_base<List, std::make_index_sequence<TCount::value>, TTypes...>::remaining{}
                     .for_each(std::forward<TVisitor>(vis));
@@ -1847,6 +1847,8 @@ namespace hyperion::mpl {
             usize m_size = 0_usize;
         };
 
+        // clang-format off
+
         /// @brief Return a range of size `end - begin`,
         /// starting at `begin` and incrementing for each successive element,
         /// until the size is reached.
@@ -1854,10 +1856,16 @@ namespace hyperion::mpl {
         /// @param begin The initial value
         /// @param end The one-after-the-end value
         /// @return a range of values from `begin` to `end`
-        constexpr auto iota(MetaValue auto begin, MetaValue auto end) noexcept {
-            std::array<std::remove_cvref_t<decltype(decltype(begin)::value)>,
-                       decltype(end)::value - decltype(begin)::value>
+        constexpr auto iota(MetaValue auto begin, MetaValue auto end) noexcept
+            -> std::array<std::remove_cvref_t<decltype(decltype(begin)::value)>,
+                          decltype(end)::value - decltype(begin)::value>
+        {
+            std::array<
+                std::remove_cvref_t<decltype(decltype(begin)::value)>,
+                decltype(end)::value - decltype(begin)::value
+            >
                 range{};
+            //clang-format on
             auto curr = decltype(begin)::value;
             for(auto& elem : range) {
                 elem = curr++;
@@ -1870,7 +1878,7 @@ namespace hyperion::mpl {
         /// @return a `static_vector<TType, TCapacity>` containing the elements
         /// of the `range`
         template<typename TType, usize TCapacity>
-        constexpr auto to_vector(auto&& range) noexcept {
+        constexpr auto to_vector(auto&& range) noexcept -> static_vector<TType, TCapacity> {
             static_vector<TType, TCapacity> arr{};
             for(const auto& elem : range) {
                 arr.push_back(elem);

--- a/include/hyperion/mpl/list.h
+++ b/include/hyperion/mpl/list.h
@@ -1857,8 +1857,10 @@ namespace hyperion::mpl {
         /// @param end The one-after-the-end value
         /// @return a range of values from `begin` to `end`
         constexpr auto iota(MetaValue auto begin, MetaValue auto end) noexcept
+#if !HYPERION_PLATFORM_COMPILER_IS_MSVC
             -> std::array<std::remove_cvref_t<decltype(decltype(begin)::value)>,
                           decltype(end)::value - decltype(begin)::value>
+#endif // !HYPERION_PLATFORM_COMPILER_IS_MSVC
         {
             std::array<
                 std::remove_cvref_t<decltype(decltype(begin)::value)>,
@@ -1878,7 +1880,11 @@ namespace hyperion::mpl {
         /// @return a `static_vector<TType, TCapacity>` containing the elements
         /// of the `range`
         template<typename TType, usize TCapacity>
-        constexpr auto to_vector(auto&& range) noexcept -> static_vector<TType, TCapacity> {
+        constexpr auto to_vector(auto&& range) noexcept
+#if !HYPERION_PLATFORM_COMPILER_IS_MSVC
+            -> static_vector<TType, TCapacity>
+#endif // !HYPERION_PLATFORM_COMPILER_IS_MSVC
+        {
             static_vector<TType, TCapacity> arr{};
             for(const auto& elem : range) {
                 arr.push_back(elem);

--- a/include/hyperion/mpl/list.h
+++ b/include/hyperion/mpl/list.h
@@ -1,8 +1,8 @@
 /// @file list.h
 /// @author Braxton Salyer <braxtonsalyer@gmail.com>
 /// @brief Meta-programming facilities for working with a list of types or values
-/// @version 0.8.1
-/// @date 2025-07-08
+/// @version 0.8.2
+/// @date 2025-11-24
 ///
 /// MIT License
 /// @copyright Copyright (c) 2025 Braxton Salyer <braxtonsalyer@gmail.com>

--- a/include/hyperion/mpl/metapredicates.h
+++ b/include/hyperion/mpl/metapredicates.h
@@ -503,6 +503,64 @@ namespace hyperion::mpl {
     };
 
     /// @brief Metaprogramming predicate object used to query whether a
+    /// `MetaType` argument represents a type that is reference qualified.
+    ///
+    /// Determines whether the represented type is reference qualified as
+    /// if by `decltype_(type).is_reference()`.
+    ///
+    /// # Requirements
+    /// - `type` must be an instance of a `MetaType`
+    ///
+    /// # Example
+    /// @code {.cpp}
+    /// constexpr auto example1 = decltype_<const int&&>{};
+    /// constexpr auto example2 = decltype_<int&>{};
+    /// constexpr auto example3 = decltype_<int>{};
+    ///
+    /// static_assert(example1.satisfies(is_reference));
+    /// static_assert(example2.satisfies(is_reference));
+    /// static_assert(not example3.satisfies(is_reference));
+    /// @endcode
+    ///
+    /// @param type The `MetaType` representing the type to check that is a reference
+    /// @return whether the type represented by `type` is a reference
+    /// @ingroup metapredicates
+    /// @headerfile hyperion/mpl/metapredicates.h
+    constexpr auto is_reference = [](MetaType auto type) noexcept {
+        return decltype_(type).is_reference();
+    };
+
+    /// @brief Metaprogramming predicate object used to query whether a
+    /// `MetaType` argument represents a type that is a pointer.
+    ///
+    /// Determines whether the represented type is a pointer as
+    /// if by `decltype_(type).is_pointer()`.
+    ///
+    /// # Requirements
+    /// - `type` must be an instance of a `MetaType`
+    ///
+    /// # Example
+    /// @code {.cpp}
+    /// constexpr auto example1 = decltype_<const int&&>{};
+    /// constexpr auto example2 = decltype_<int*>{};
+    /// constexpr auto example3 = decltype_<const int*>{};
+    /// constexpr auto example4 = decltype_<int>{};
+    ///
+    /// static_assert(not example1.satisfies(is_pointer));
+    /// static_assert(example2.satisfies(is_pointer));
+    /// static_assert(example3.satisfies(is_pointer));
+    /// static_assert(not example4.satisfies(is_poitner));
+    /// @endcode
+    ///
+    /// @param type The `MetaType` representing the type to check that is a pointer
+    /// @return whether the type represented by `type` is a pointer
+    /// @ingroup metapredicates
+    /// @headerfile hyperion/mpl/metapredicates.h
+    constexpr auto is_pointer = [](MetaType auto type) noexcept {
+        return decltype_(type).is_pointer();
+    };
+
+    /// @brief Metaprogramming predicate object used to query whether a
     /// `MetaType` argument represents a type that is `volatile` qualified.
     ///
     /// Determines whether the represented type is `volatile` as if by

--- a/include/hyperion/mpl/metapredicates.h
+++ b/include/hyperion/mpl/metapredicates.h
@@ -26,16 +26,13 @@
 /// SOFTWARE.
 
 #ifndef HYPERION_MPL_METAPREDICATES_H
-    #define HYPERION_MPL_METAPREDICATES_H
+#define HYPERION_MPL_METAPREDICATES_H
 
 #include <hyperion/platform/def.h>
 //
 #include <hyperion/mpl/metatypes.h>
 #include <hyperion/mpl/type.h>
 #include <hyperion/mpl/value.h>
-
-#include <concepts>
-#include <type_traits>
 
 /// @ingroup mpl
 /// @{
@@ -139,9 +136,9 @@ namespace hyperion::mpl {
                          || (MetaType<decltype(element)> && MetaType<decltype(value)>)
                          || (MetaPair<decltype(element)> && MetaPair<decltype(value)>))
             {
-                return Value < detail::convert_to_meta_t<decltype(element)>{}
-                           == detail::convert_to_meta_t<decltype(value)>{},
-                       bool > {};
+                return Value<detail::convert_to_meta_t<decltype(element)>{}
+                                 == detail::convert_to_meta_t<decltype(value)>{},
+                             bool>{};
             }
             else {
                 return Value<false>{};
@@ -417,7 +414,7 @@ namespace hyperion::mpl {
         };
     }
 
-HYPERION_IGNORE_DOCUMENTATION_WARNING_START;
+    HYPERION_IGNORE_DOCUMENTATION_WARNING_START;
 
     /// @brief Metaprogramming predicate object used to query whether a
     /// `MetaType` argument represents a type that is `const` qualified.
@@ -533,7 +530,59 @@ HYPERION_IGNORE_DOCUMENTATION_WARNING_START;
         return decltype_(type).is_volatile();
     };
 
-HYPERION_IGNORE_DOCUMENTATION_WARNING_STOP;
+    /// @brief Metaprogramming predicate object used to query whether a
+    /// `MetaType` argument represents a type that is empty.
+    ///
+    /// Determines whether the represented type is empty as if by
+    /// `decltype_(type).is_empty()`.
+    ///
+    /// # Requirements
+    /// - `type` must be an instance of a `MetaType`
+    ///
+    /// # Example
+    /// @code {.cpp}
+    /// struct empty {};
+    /// static_assert(decltype_<empty>().satisfies(is_empty));
+    /// static_assert(not decltype_<int>().satisfies(is_empty));
+    /// @endcode
+    ///
+    /// @param type The `MetaType` representing the type to check that is empty
+    /// @return whether the type represented by `type` is empty
+    /// @ingroup metapredicates
+    /// @headerfile hyperion/mpl/metapredicates.h
+    constexpr auto is_empty = [](MetaType auto type) noexcept {
+        return decltype_(type).is_empty();
+    };
+
+    /// @brief Metaprogramming predicate object used to query whether a
+    /// `MetaType` argument represents a type that is trivial.
+    ///
+    /// Determines whether the represented type is trivial as if by
+    /// `decltype_(type).is_trivial()`.
+    ///
+    /// # Requirements
+    /// - `type` must be an instance of a `MetaType`
+    ///
+    /// # Example
+    /// @code {.cpp}
+    /// struct trivial {};
+    /// struct not_trivial {
+    ///     not_trivial(const not_trivial&);
+    /// }
+    /// static_assert(decltype_<trivial>().satisfies(is_trivial));
+    /// static_assert(decltype_<int>().satisfies(is_trivial));
+    /// static_assert(not decltype_<not_trivial>().satisfies(is_trivial));
+    /// @endcode
+    ///
+    /// @param type The `MetaType` representing the type to check that is trivial
+    /// @return whether the type represented by `type` is trivial
+    /// @ingroup metapredicates
+    /// @headerfile hyperion/mpl/metapredicates.h
+    constexpr auto is_trivial = [](MetaType auto type) noexcept {
+        return decltype_(type).is_trivial();
+    };
+
+    HYPERION_IGNORE_DOCUMENTATION_WARNING_STOP;
 
     /// @brief Returns a metaprogramming predicate object used to query whether a
     /// `MetaType` argument represents a type that is convertible to the type
@@ -810,7 +859,7 @@ HYPERION_IGNORE_DOCUMENTATION_WARNING_STOP;
         };
     }
 
-HYPERION_IGNORE_DOCUMENTATION_WARNING_START;
+    HYPERION_IGNORE_DOCUMENTATION_WARNING_START;
 
     /// @brief Metaprogramming predicate object used to query whether a
     /// `MetaType` argument represents a type that is default constructible.
@@ -1315,6 +1364,132 @@ HYPERION_IGNORE_DOCUMENTATION_WARNING_START;
         return decltype_(type).is_noexcept_move_assignable();
     };
 
+    /// @brief Returns a metaprogramming predicate object used to query whether a
+    /// `MetaType` argument represents a type that is assignable from a value of type `type`.
+    ///
+    /// The returned metaprogramming predicate object has call operator equivalent to
+    /// `constexpr operator()(MetaType auto self) noexcept`, that when invoked, returns
+    /// whether `self` represents a type assignable from a value of the type represented by `type`,
+    /// determined as if by `decltype_(self).is_assignable_from(decltype_(type))`.
+    ///
+    /// # Requirements
+    /// - `type` must be an instance of a `MetaType`
+    ///
+    /// # Example
+    /// @code {.cpp}
+    /// struct example {
+    ///     auto operator=(int) -> example&;
+    /// };
+    /// constexpr auto example1 = decltype_<example>{};
+    ///
+    /// static_assert(example1.satisfies(assignable_from(decltype_<example>())));
+    /// static_assert(example1.satisfies(assignable_from(decltype_<int>())));
+    /// static_assert(not example1.satisfies(assignable_from(decltype_<std::string>())));
+    /// @endcode
+    ///
+    /// @param type The `MetaType` representing the type to check for assignability from
+    /// @return A metaprogramming predicate object to check that an argument represents
+    /// a type that is assignable from an argument of the type represented by `type`
+    /// @ingroup metapredicates
+    /// @headerfile hyperion/mpl/metapredicates.h
+    constexpr auto assignable_from(MetaType auto type) noexcept {
+        return [](MetaType auto self) noexcept {
+            return decltype_(self).is_assignable_from(decltype(type){});
+        };
+    }
+
+    /// @brief Returns a metaprogramming predicate object used to query whether a
+    /// `MetaType` argument represents a type that is `noexcept` assignable
+    /// from a value of type `type`.
+    ///
+    /// The returned metaprogramming predicate object has call operator equivalent to
+    /// `constexpr operator()(MetaType auto self) noexcept`, that when invoked, returns
+    /// whether `self` represents a type `noexcept` assignable from a value of the type
+    /// represented by `type`, determined as if by
+    /// `decltype_(self).is_noexcept_assignable_from(decltype_(type))`.
+    ///
+    /// # Requirements
+    /// - `type` must be an instance of a `MetaType`
+    ///
+    /// # Example
+    /// @code {.cpp}
+    /// struct yes {
+    ///     auto operator=(int) noexcept -> example&;
+    /// };
+    ///
+    /// struct no {
+    ///     auto operator=(int) -> example&;
+    /// };
+    ///
+    /// constexpr auto example1 = decltype_<yes>{};
+    /// constexpr auto example2 = decltype_<no>{};
+    ///
+    /// static_assert(example1.satisfies(noexcept_assignable_from(decltype_<yes>())));
+    /// static_assert(example1.satisfies(noexcept_assignable_from(decltype_<int>())));
+    /// static_assert(not example1.satisfies(noexcept_assignable_from(decltype_<std::string>())));
+    /// static_assert(not example2.satisfies(noexcept_assignable_from(decltype_<int>())));
+    /// @endcode
+    ///
+    /// @param type The `MetaType` representing the type to check for assignability from
+    /// @return A metaprogramming predicate object to check that an argument represents
+    /// a type that is `noexcept` assignable from an argument of the type represented by `type`
+    /// @ingroup metapredicates
+    /// @headerfile hyperion/mpl/metapredicates.h
+    constexpr auto noexcept_assignable_from(MetaType auto type) noexcept {
+        return [](MetaType auto self) noexcept {
+            return decltype_(self).is_noexcept_assignable_from(decltype(type){});
+        };
+    }
+
+    /// @brief Returns a metaprogramming predicate object used to query whether a
+    /// `MetaType` argument represents a type that is trivially assignable
+    /// from a value of type `type`.
+    ///
+    /// The returned metaprogramming predicate object has call operator equivalent to
+    /// `constexpr operator()(MetaType auto self) noexcept`, that when invoked, returns
+    /// whether `self` represents a type trivially assignable from a value of the type
+    /// represented by `type`, determined as if by
+    /// `decltype_(self).is_trivially_assignable_from(decltype_(type))`.
+    ///
+    /// # Requirements
+    /// - `type` must be an instance of a `MetaType`
+    ///
+    /// # Example
+    /// @code {.cpp}
+    /// struct first {
+    /// };
+    ///
+    /// struct second {
+    ///     auto operator=(const second&) noexcept -> second& = default;
+    ///     auto operator=(second&&) noexcept -> second& = default;
+    /// };
+    ///
+    /// struct third {
+    ///     auto operator=(const second&) noexcept -> third&;
+    ///     auto operator=(second&&) noexcept -> third&;
+    /// };
+    ///
+    /// constexpr auto example1 = decltype_<first>{};
+    /// constexpr auto example2 = decltype_<second>{};
+    /// constexpr auto example3 = decltype_<third>{};
+    ///
+    /// static_assert(example1.satisfies(trivially_assignable_from(decltype_<first>())));
+    /// static_assert(example2.satisfies(trivially_assignable_from(decltype_<second>())));
+    /// static_assert(not example1.satisfies(trivially_assignable_from(decltype_<std::string>())));
+    /// static_assert(not example3.satisfies(trivially_assignable_from(decltype_<third>())));
+    /// @endcode
+    ///
+    /// @param type The `MetaType` representing the type to check for assignability from
+    /// @return A metaprogramming predicate object to check that an argument represents
+    /// a type that is trivially assignable from an argument of the type represented by `type`
+    /// @ingroup metapredicates
+    /// @headerfile hyperion/mpl/metapredicates.h
+    constexpr auto trivially_assignable_from(MetaType auto type) noexcept {
+        return [](MetaType auto self) noexcept {
+            return decltype_(self).is_trivially_assignable_from(decltype(type){});
+        };
+    }
+
     /// @brief Metaprogramming predicate object used to query whether a
     /// `MetaType` argument represents a type that is trivially move assignable.
     ///
@@ -1531,7 +1706,7 @@ HYPERION_IGNORE_DOCUMENTATION_WARNING_START;
         return decltype_(type).is_noexcept_swappable();
     };
 
-HYPERION_IGNORE_DOCUMENTATION_WARNING_STOP;
+    HYPERION_IGNORE_DOCUMENTATION_WARNING_STOP;
 
     /// @brief Returns a metaprogramming predicate object used to query whether a
     /// `MetaType` argument represents a type that is swappable with the type
@@ -1544,7 +1719,7 @@ HYPERION_IGNORE_DOCUMENTATION_WARNING_STOP;
     /// The returned metaprogramming predicate object has call operator equivalent to
     /// `constexpr operator()(MetaType auto arg) noexcept`, that when invoked, returns
     /// whether `arg` represents a type swappable with the type represented by `type`,
-    /// determined as if by `decltype_(element).is_swappable_with(decltype_(type))`.
+    /// determined as if by `decltype_(arg).is_swappable_with(decltype_(type))`.
     ///
     /// # Requirements
     /// - `type` must be an instance of a `MetaType`
@@ -1590,7 +1765,7 @@ HYPERION_IGNORE_DOCUMENTATION_WARNING_STOP;
     /// to `constexpr operator()(MetaType auto arg) noexcept`, that when invoked,
     /// returns whether `arg` represents a type `noexcept` swappable with the type
     /// represented by `type`, determined as if by
-    /// `decltype_(element).is_noexcept_swappable_with(decltype_(type))`.
+    /// `decltype_(arg).is_noexcept_swappable_with(decltype_(type))`.
     ///
     /// # Requirements
     /// - `type` must be an instance of a `MetaType`

--- a/include/hyperion/mpl/metapredicates.h
+++ b/include/hyperion/mpl/metapredicates.h
@@ -1,8 +1,8 @@
 /// @file metapredicates.h
 /// @author Braxton Salyer <braxtonsalyer@gmail.com>
 /// @brief Callable definitions for common metaprogramming predicates
-/// @version 0.1.3
-/// @date 2025-07-08
+/// @version 0.2.0
+/// @date 2025-11-24
 ///
 /// MIT License
 /// @copyright Copyright (c) 2025 Braxton Salyer <braxtonsalyer@gmail.com>

--- a/include/hyperion/mpl/type.h
+++ b/include/hyperion/mpl/type.h
@@ -1,8 +1,8 @@
 /// @file type.h
 /// @author Braxton Salyer <braxtonsalyer@gmail.com>
 /// @brief Metaprogramming type wrapper for use as metafunction parameter and return type
-/// @version 0.2.0
-/// @date 2025-07-10
+/// @version 0.3.0
+/// @date 2025-11-24
 ///
 /// MIT License
 /// @copyright Copyright (c) 2025 Braxton Salyer <braxtonsalyer@gmail.com>

--- a/src/test/list.h
+++ b/src/test/list.h
@@ -1,8 +1,8 @@
 /// @file list.h
 /// @author Braxton Salyer <braxtonsalyer@gmail.com>
 /// @brief Tests for list.h
-/// @version 0.8.1
-/// @date 2025-07-08
+/// @version 0.8.2
+/// @date 2025-11-24
 ///
 /// MIT License
 /// @copyright Copyright (c) 2025 Braxton Salyer <braxtonsalyer@gmail.com>

--- a/src/test/metapredicates.h
+++ b/src/test/metapredicates.h
@@ -1,8 +1,8 @@
 /// @file metapredicates.h
 /// @author Braxton Salyer <braxtonsalyer@gmail.com>
 /// @brief Tests for metapredicates.h
-/// @version 0.1.3
-/// @date 2025-07-08
+/// @version 0.2.0
+/// @date 2025-11-24
 ///
 /// MIT License
 /// @copyright Copyright (c) 2025 Braxton Salyer <braxtonsalyer@gmail.com>

--- a/src/test/metapredicates.h
+++ b/src/test/metapredicates.h
@@ -91,24 +91,38 @@ namespace hyperion::mpl::_test::metapredicates {
                   "hyperion::mpl::qualification_of predicate test case 4 (failing)");
 
     static_assert(decltype_<const int>().satisfies(is_const),
-                  "hyperion::mpl::is_const predicat test case 1 (failing)");
+                  "hyperion::mpl::is_const predicate test case 1 (failing)");
     static_assert(not decltype_<int>().satisfies(is_const),
-                  "hyperion::mpl::is_const predicat test case 2 (failing)");
+                  "hyperion::mpl::is_const predicate test case 2 (failing)");
 
     static_assert(decltype_<int&>().satisfies(is_lvalue_reference),
-                  "hyperion::mpl::is_lvalue_reference predicat test case 1 (failing)");
+                  "hyperion::mpl::is_lvalue_reference predicate test case 1 (failing)");
     static_assert(not decltype_<int>().satisfies(is_lvalue_reference),
-                  "hyperion::mpl::is_lvalue_reference predicat test case 2 (failing)");
+                  "hyperion::mpl::is_lvalue_reference predicate test case 2 (failing)");
 
     static_assert(decltype_<int&&>().satisfies(is_rvalue_reference),
-                  "hyperion::mpl::is_rvalue_reference predicat test case 1 (failing)");
+                  "hyperion::mpl::is_rvalue_reference predicate test case 1 (failing)");
     static_assert(not decltype_<int>().satisfies(is_rvalue_reference),
-                  "hyperion::mpl::is_rvalue_reference predicat test case 2 (failing)");
+                  "hyperion::mpl::is_rvalue_reference predicate test case 2 (failing)");
+
+    static_assert(decltype_<int&>().satisfies(is_reference),
+                  "hyperion::mpl::is_reference predicate test case 1 (failing)");
+    static_assert(not decltype_<int>().satisfies(is_reference),
+                  "hyperion::mpl::is_reference predicate test case 2 (failing)");
+    static_assert(decltype_<int&&>().satisfies(is_reference),
+                  "hyperion::mpl::is_reference predicate test case 3 (failing)");
+
+    static_assert(decltype_<int*>().satisfies(is_pointer),
+                  "hyperion::mpl::is_pointer predicate test case 1 (failing)");
+    static_assert(not decltype_<int>().satisfies(is_pointer),
+                  "hyperion::mpl::is_pointer predicate test case 2 (failing)");
+    static_assert(decltype_<const int* const>().satisfies(is_pointer),
+                  "hyperion::mpl::is_pointer predicate test case 3 (failing)");
 
     static_assert(decltype_<volatile int>().satisfies(is_volatile),
-                  "hyperion::mpl::is_volatile predicat test case 1 (failing)");
+                  "hyperion::mpl::is_volatile predicate test case 1 (failing)");
     static_assert(not decltype_<int>().satisfies(is_volatile),
-                  "hyperion::mpl::is_volatile predicat test case 2 (failing)");
+                  "hyperion::mpl::is_volatile predicate test case 2 (failing)");
 
     struct empty { };
 

--- a/src/test/metapredicates.h
+++ b/src/test/metapredicates.h
@@ -110,6 +110,23 @@ namespace hyperion::mpl::_test::metapredicates {
     static_assert(not decltype_<int>().satisfies(is_volatile),
                   "hyperion::mpl::is_volatile predicat test case 2 (failing)");
 
+    struct empty { };
+
+    static_assert(decltype_<empty>().satisfies(is_empty),
+                  "hyperion::mpl::is_empty test case 1 (failing)");
+    static_assert(not decltype_<int>().satisfies(is_empty),
+                  "hyperion::mpl::is_empty test case 2 (failing)");
+
+    struct not_trivial {
+        not_trivial(const not_trivial&);
+    };
+    static_assert(decltype_<empty>().satisfies(is_trivial),
+                  "hyperion::mpl::is_trivial test case 1 (failing)");
+    static_assert(decltype_<int>().satisfies(is_trivial),
+                  "hyperion::mpl::is_trivial test case 2 (failing)");
+    static_assert(not decltype_<not_trivial>().satisfies(is_trivial),
+                  "hyperion::mpl::is_trivial test case 3 (failing)");
+
     struct not_convertible { };
 
     static_assert(decltype_<int>().satisfies(convertible_to(decltype_<float>())),
@@ -503,6 +520,52 @@ namespace hyperion::mpl::_test::metapredicates {
                   "hyperion::mpl::trivially_move_assignable predicate test case 4 (failing)");
     static_assert(not decltype_<not_move_assignable>().satisfies(mpl::trivially_move_assignable),
                   "hyperion::mpl::trivially_move_assignable predicate test case 5 (failing)");
+
+    struct base_type { };
+
+    template<typename T>
+    struct assignable_from {
+        auto operator=(T) -> assignable_from& {
+            return *this;
+        }
+    };
+
+    template<typename T>
+    struct noexcept_assignable_from {
+        auto operator=(T) -> noexcept_assignable_from& {
+            return *this;
+        }
+    };
+
+    static_assert(
+        decltype_<assignable_from<int>>().satisfies(mpl::assignable_from(decltype_<int>())),
+        "hyperion::mpl::assignable_from test case 1 (failing)");
+    static_assert(decltype_<assignable_from<int>>().satisfies(
+                      mpl::assignable_from(decltype_<assignable_from<int>>())),
+                  "hyperion::mpl::assignable_from test case 2 (failing)");
+    static_assert(not decltype_<assignable_from<int>>().satisfies(
+                      mpl::assignable_from(decltype_<base_type>())),
+                  "hyperion::mpl::assignable_from test case 3 (failing)");
+
+    static_assert(decltype_<assignable_from<int>>().satisfies(
+                      mpl::noexcept_assignable_from(decltype_<assignable_from<int>>())),
+                  "hyperion::mpl::noexcept_assignable_from test case 1 (failing)");
+    static_assert(not decltype_<assignable_from<int>>().satisfies(
+                      mpl::noexcept_assignable_from(decltype_<int>())),
+                  "hyperion::mpl::noexcept_assignable_from test case 2 (failing)");
+    static_assert(not decltype_<assignable_from<int>>().satisfies(
+                      mpl::noexcept_assignable_from(decltype_<base_type>())),
+                  "hyperion::mpl::noexcept_assignable_from test case 3 (failing)");
+
+    static_assert(decltype_<assignable_from<int>>().satisfies(
+                      mpl::trivially_assignable_from(decltype_<assignable_from<int>>())),
+                  "hyperion::mpl::trivially_assignable_from test case 1 (failing)");
+    static_assert(not decltype_<assignable_from<int>>().satisfies(
+                      mpl::trivially_assignable_from(decltype_<int>())),
+                  "hyperion::mpl::trivially_assignable_from test case 2 (failing)");
+    static_assert(not decltype_<assignable_from<int>>().satisfies(
+                      mpl::trivially_assignable_from(decltype_<base_type>())),
+                  "hyperion::mpl::trivially_assignable_from test case 3 (failing)");
 
     // NOLINTNEXTLINE(*-special-member-functions)
     struct not_destructible {

--- a/src/test/type.h
+++ b/src/test/type.h
@@ -360,12 +360,51 @@ namespace hyperion::mpl::_test::type {
     static_assert(!decltype_<int>().is_volatile(),
                   "hyperion::mpl::Type::is_volatile test case 3 (failing)");
 
+    struct empty { };
+
+    static_assert(decltype_<empty>().is_empty(),
+                  "hyperion::mpl::Type::is_empty test case 1 (failing)");
+    static_assert(not decltype_<int>().is_empty(),
+                  "hyperion::mpl::Type::is_empty test case 2 (failing)");
+
+    struct not_trivial {
+        not_trivial(const not_trivial&);
+    };
+    static_assert(decltype_<empty>().is_trivial(),
+                  "hyperion::mpl::Type::is_trivial test case 1 (failing)");
+    static_assert(decltype_<int>().is_trivial(),
+                  "hyperion::mpl::Type::is_trivial test case 2 (failing)");
+    static_assert(not decltype_<not_trivial>().is_trivial(),
+                  "hyperion::mpl::Type::is_trivial test case 3 (failing)");
+
     static_assert(decltype_<int&&>().is_rvalue_reference(),
                   "hyperion::mpl::Type::is_rvalue_reference test case 1 (failing)");
     static_assert(decltype_<const int&&>().is_rvalue_reference(),
                   "hyperion::mpl::Type::is_rvalue_reference test case 2 (failing)");
     static_assert(!decltype_<int>().is_rvalue_reference(),
                   "hyperion::mpl::Type::is_rvalue_reference test case 3 (failing)");
+
+    static_assert(decltype_<int&>().is_reference(),
+                  "hyperion::mpl::Type::is_reference test case 1 (failing)");
+    static_assert(decltype_<const int&>().is_reference(),
+                  "hyperion::mpl::Type::is_reference test case 2 (failing)");
+    static_assert(decltype_<int&&>().is_reference(),
+                  "hyperion::mpl::Type::is_reference test case 3 (failing)");
+    static_assert(decltype_<const int&&>().is_reference(),
+                  "hyperion::mpl::Type::is_reference test case 4 (failing)");
+    static_assert(not decltype_<int>().is_reference(),
+                  "hyperion::mpl::Type::is_reference test case 5 (failing)");
+
+    static_assert(not decltype_<int>().is_pointer(),
+                  "hyperion::mpl::Type::is_pointer test case 1 (failing)");
+    static_assert(decltype_<int*>().is_pointer(),
+                  "hyperion::mpl::Type::is_pointer test case 2 (failing)");
+    static_assert(decltype_<int* const>().is_pointer(),
+                  "hyperion::mpl::Type::is_pointer test case 3 (failing)");
+    static_assert(decltype_<const int*>().is_pointer(),
+                  "hyperion::mpl::Type::is_pointer test case 4 (failing)");
+    static_assert(decltype_<const int* const>().is_pointer(),
+                  "hyperion::mpl::Type::is_pointer test case 5 (failing)");
 
     static_assert(decltype_<int>().as_const() == decltype_<const int>(),
                   "hyperion::mpl::Type::as_const test case 1 (failing)");
@@ -394,6 +433,116 @@ namespace hyperion::mpl::_test::type {
                   "hyperion::mpl::Type::as_rvalue_reference test case 2 (failing)");
     static_assert(decltype_<int>().as_rvalue_reference() != decltype_<int>(),
                   "hyperion::mpl::Type::as_rvalue_reference test case 3 (failing)");
+
+    static_assert(decltype_<int>().as_pointer() == decltype_<int*>(),
+                  "hyperion::mpl::Type::as_pointer test case 1 (failing)");
+    static_assert(decltype_<const int>().as_pointer() == decltype_<const int*>(),
+                  "hyperion::mpl::Type::as_pointer test case 2 (failing)");
+    static_assert(decltype_<int&>().as_pointer() == decltype_<int*>(),
+                  "hyperion::mpl::Type::as_pointer test case 3 (failing)");
+    static_assert(decltype_<int*>().as_pointer() == decltype_<int**>(),
+                  "hyperion::mpl::Type::as_pointer test case 4 (failing)");
+
+    static_assert(decltype_<int>().remove_lvalue_reference() == decltype_<int>(),
+                  "hyperion::mpl::Type::remove_lvalue_reference test case 1 (failing)");
+    static_assert(decltype_<const int>().remove_lvalue_reference() == decltype_<const int>(),
+                  "hyperion::mpl::Type::remove_lvalue_reference test case 2 (failing)");
+    static_assert(decltype_<int&>().remove_lvalue_reference() == decltype_<int>(),
+                  "hyperion::mpl::Type::remove_lvalue_reference test case 3 (failing)");
+    static_assert(decltype_<const int&>().remove_lvalue_reference() == decltype_<const int>(),
+                  "hyperion::mpl::Type::remove_lvalue_reference test case 4 (failing)");
+    static_assert(decltype_<int&&>().remove_lvalue_reference() == decltype_<int&&>(),
+                  "hyperion::mpl::Type::remove_lvalue_reference test case 5 (failing)");
+    static_assert(decltype_<const int&&>().remove_lvalue_reference() == decltype_<const int&&>(),
+                  "hyperion::mpl::Type::remove_lvalue_reference test case 6 (failing)");
+
+    static_assert(decltype_<int>().remove_rvalue_reference() == decltype_<int>(),
+                  "hyperion::mpl::Type::remove_rvalue_reference test case 1 (failing)");
+    static_assert(decltype_<const int>().remove_rvalue_reference() == decltype_<const int>(),
+                  "hyperion::mpl::Type::remove_rvalue_reference test case 2 (failing)");
+    static_assert(decltype_<int&>().remove_rvalue_reference() == decltype_<int&>(),
+                  "hyperion::mpl::Type::remove_rvalue_reference test case 3 (failing)");
+    static_assert(decltype_<const int&>().remove_rvalue_reference() == decltype_<const int&>(),
+                  "hyperion::mpl::Type::remove_rvalue_reference test case 4 (failing)");
+    static_assert(decltype_<int&&>().remove_rvalue_reference() == decltype_<int>(),
+                  "hyperion::mpl::Type::remove_rvalue_reference test case 5 (failing)");
+    static_assert(decltype_<const int&&>().remove_rvalue_reference() == decltype_<const int>(),
+                  "hyperion::mpl::Type::remove_rvalue_reference test case 6 (failing)");
+
+    static_assert(decltype_<int>().remove_reference() == decltype_<int>(),
+                  "hyperion::mpl::Type::remove_reference  test case 1 (failing)");
+    static_assert(decltype_<const int>().remove_reference() == decltype_<const int>(),
+                  "hyperion::mpl::Type::remove_reference  test case 2 (failing)");
+    static_assert(decltype_<int&>().remove_reference() == decltype_<int>(),
+                  "hyperion::mpl::Type::remove_reference  test case 3 (failing)");
+    static_assert(decltype_<const int&>().remove_reference() == decltype_<const int>(),
+                  "hyperion::mpl::Type::remove_reference  test case 4 (failing)");
+    static_assert(decltype_<int&&>().remove_reference() == decltype_<int>(),
+                  "hyperion::mpl::Type::remove_reference  test case 5 (failing)");
+    static_assert(decltype_<const int&&>().remove_reference() == decltype_<const int>(),
+                  "hyperion::mpl::Type::remove_reference  test case 6 (failing)");
+
+    static_assert(decltype_<int>().remove_const() == decltype_<int>(),
+                  "hyperion::mpl::Type::remove_const  test case 1 (failing)");
+    static_assert(decltype_<const int>().remove_const() == decltype_<int>(),
+                  "hyperion::mpl::Type::remove_const  test case 2 (failing)");
+    static_assert(decltype_<int&>().remove_const() == decltype_<int&>(),
+                  "hyperion::mpl::Type::remove_const  test case 3 (failing)");
+    static_assert(decltype_<const int&>().remove_const() == decltype_<int&>(),
+                  "hyperion::mpl::Type::remove_const  test case 4 (failing)");
+    static_assert(decltype_<int&&>().remove_const() == decltype_<int&&>(),
+                  "hyperion::mpl::Type::remove_const  test case 5 (failing)");
+    static_assert(decltype_<const int&&>().remove_const() == decltype_<int&&>(),
+                  "hyperion::mpl::Type::remove_const  test case 6 (failing)");
+    static_assert(decltype_<const int*>().remove_const() == decltype_<const int*>(),
+                  "hyperion::mpl::Type::remove_const  test case 7 (failing)");
+    static_assert(decltype_<const int* const>().remove_const() == decltype_<const int*>(),
+                  "hyperion::mpl::Type::remove_const  test case 8 (failing)");
+
+    static_assert(decltype_<int>().remove_volatile() == decltype_<int>(),
+                  "hyperion::mpl::Type::remove_volatile  test case 1 (failing)");
+    static_assert(decltype_<volatile int>().remove_volatile() == decltype_<int>(),
+                  "hyperion::mpl::Type::remove_volatile  test case 2 (failing)");
+    static_assert(decltype_<int&>().remove_volatile() == decltype_<int&>(),
+                  "hyperion::mpl::Type::remove_volatile  test case 3 (failing)");
+    static_assert(decltype_<volatile int&>().remove_volatile() == decltype_<int&>(),
+                  "hyperion::mpl::Type::remove_volatile  test case 4 (failing)");
+    static_assert(decltype_<int&&>().remove_volatile() == decltype_<int&&>(),
+                  "hyperion::mpl::Type::remove_volatile  test case 5 (failing)");
+    static_assert(decltype_<volatile int&&>().remove_volatile() == decltype_<int&&>(),
+                  "hyperion::mpl::Type::remove_volatile  test case 6 (failing)");
+    static_assert(decltype_<volatile int*>().remove_volatile() == decltype_<volatile int*>(),
+                  "hyperion::mpl::Type::remove_volatile  test case 7 (failing)");
+    static_assert(decltype_<volatile int* volatile>().remove_volatile()
+                      == decltype_<volatile int*>(),
+                  "hyperion::mpl::Type::remove_volatile  test case 8 (failing)");
+
+    static_assert(decltype_<int>().unqualified() == decltype_<int>(),
+                  "hyperion::mpl::Type::unqualified  test case 1 (failing)");
+    static_assert(decltype_<const int>().unqualified() == decltype_<int>(),
+                  "hyperion::mpl::Type::unqualified  test case 2 (failing)");
+    static_assert(decltype_<int&>().unqualified() == decltype_<int>(),
+                  "hyperion::mpl::Type::unqualified  test case 3 (failing)");
+    static_assert(decltype_<const int&>().unqualified() == decltype_<int>(),
+                  "hyperion::mpl::Type::unqualified  test case 4 (failing)");
+    static_assert(decltype_<int&&>().unqualified() == decltype_<int>(),
+                  "hyperion::mpl::Type::unqualified  test case 5 (failing)");
+    static_assert(decltype_<const int&&>().unqualified() == decltype_<int>(),
+                  "hyperion::mpl::Type::unqualified  test case 6 (failing)");
+    static_assert(decltype_<const int*>().unqualified() == decltype_<const int*>(),
+                  "hyperion::mpl::Type::unqualified  test case 7 (failing)");
+    static_assert(decltype_<const int* const>().unqualified() == decltype_<const int*>(),
+                  "hyperion::mpl::Type::unqualified  test case 8 (failing)");
+    static_assert(decltype_<volatile int>().unqualified() == decltype_<int>(),
+                  "hyperion::mpl::Type::unqualified  test case 9 (failing)");
+    static_assert(decltype_<volatile int&>().unqualified() == decltype_<int>(),
+                  "hyperion::mpl::Type::unqualified  test case 10 (failing)");
+    static_assert(decltype_<volatile int&&>().unqualified() == decltype_<int>(),
+                  "hyperion::mpl::Type::unqualified  test case 11 (failing)");
+    static_assert(decltype_<volatile int*>().unqualified() == decltype_<volatile int*>(),
+                  "hyperion::mpl::Type::unqualified  test case 12 (failing)");
+    static_assert(decltype_<volatile int* volatile>().unqualified() == decltype_<volatile int*>(),
+                  "hyperion::mpl::Type::unqualified  test case 13 (failing)");
 
     struct not_convertible { };
 
@@ -779,6 +928,48 @@ namespace hyperion::mpl::_test::type {
                   "hyperion::mpl::Type::is_trivially_move_assignable test case 4 (failing)");
     static_assert(!decltype_<not_trivially_move_assignable>().is_trivially_move_assignable(),
                   "hyperion::mpl::Type::is_trivially_move_assignable test case 5 (failing)");
+
+    template<typename T>
+    struct assignable_from {
+        auto operator=(T) -> assignable_from& {
+            return *this;
+        }
+    };
+
+    template<typename T>
+    struct noexcept_assignable_from {
+        auto operator=(T) -> noexcept_assignable_from& {
+            return *this;
+        }
+    };
+
+    static_assert(decltype_<assignable_from<int>>().is_assignable_from(decltype_<int>()),
+                  "hyperion::mpl::Type::is_assignable_from test case 1 (failing)");
+    static_assert(
+        decltype_<assignable_from<int>>().is_assignable_from(decltype_<assignable_from<int>>()),
+        "hyperion::mpl::Type::is_assignable_from test case 2 (failing)");
+    static_assert(not decltype_<assignable_from<int>>().is_assignable_from(decltype_<base_type>()),
+                  "hyperion::mpl::Type::is_assignable_from test case 3 (failing)");
+
+    static_assert(decltype_<assignable_from<int>>().is_noexcept_assignable_from(
+                      decltype_<assignable_from<int>>()),
+                  "hyperion::mpl::Type::is_noexcept_assignable_from test case 1 (failing)");
+    static_assert(
+        not decltype_<assignable_from<int>>().is_noexcept_assignable_from(decltype_<int>()),
+        "hyperion::mpl::Type::is_noexcept_assignable_from test case 2 (failing)");
+    static_assert(
+        not decltype_<assignable_from<int>>().is_noexcept_assignable_from(decltype_<base_type>()),
+        "hyperion::mpl::Type::is_noexcept_assignable_from test case 3 (failing)");
+
+    static_assert(decltype_<assignable_from<int>>().is_trivially_assignable_from(
+                      decltype_<assignable_from<int>>()),
+                  "hyperion::mpl::Type::is_trivially_assignable_from test case 1 (failing)");
+    static_assert(
+        not decltype_<assignable_from<int>>().is_trivially_assignable_from(decltype_<int>()),
+        "hyperion::mpl::Type::is_trivially_assignable_from test case 2 (failing)");
+    static_assert(
+        not decltype_<assignable_from<int>>().is_trivially_assignable_from(decltype_<base_type>()),
+        "hyperion::mpl::Type::is_trivially_assignable_from test case 3 (failing)");
 
     // NOLINTNEXTLINE(*-special-member-functions)
     struct not_destructible {

--- a/src/test/type.h
+++ b/src/test/type.h
@@ -1,8 +1,8 @@
 /// @file type.h
 /// @author Braxton Salyer <braxtonsalyer@gmail.com>
 /// @brief Test for type.h
-/// @version 0.1.2
-/// @date 2025-07-08
+/// @version 0.3.0
+/// @date 2025-11-24
 ///
 /// MIT License
 /// @copyright Copyright (c) 2025 Braxton Salyer <braxtonsalyer@gmail.com>

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,6 +1,6 @@
 ---@diagnostic disable: undefined-global,undefined-field
 set_project("hyperion_mpl")
-set_version("0.11.0")
+set_version("0.12.0")
 
 set_xmakever("3.0.0")
 


### PR DESCRIPTION
- is_empty
- is_trivial
- is_reference
- is_pointer
- (noexcept_|trivally_)assignable_from
- as_pointer
- remove_<const|volatile|(lvalue_|rvalue_)reference>
- unqualified